### PR TITLE
Update to tendermint 0.26

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ base64      = { version = "0.13", default-features = false, features = ["alloc"]
 flex-error = { version = "0.4.4", default-features = false }
 
 [dependencies.tendermint-proto]
-version          = "=0.25.0"
+version          = "0.26.0"
 default-features = false
 
 [features]


### PR DESCRIPTION
Closes: #33

Unpin the version as tendermint-rs is no longer going to be tied to
a tendermint core version and its versioning policy has changed towards
conventional Rust-style semver compliance.