### PR TITLE
Fix path used for ICS31 proto definition

### DIFF
--- a/tools/proto-compiler/src/cmd/compile.rs
+++ b/tools/proto-compiler/src/cmd/compile.rs
@@ -37,7 +37,7 @@ impl CompileCmd {
         // Paths
         let proto_paths = [
             format!("{}/../../definitions/mock", root),
-            format!("{}/../../definitions/interchainquery/v1", root),
+            format!("{}/../../definitions/stride/interchainquery/v1", root),
             format!("{}/ibc", ibc_dir.display()),
             format!("{}/cosmos/auth", sdk_dir.display()),
             format!("{}/cosmos/gov", sdk_dir.display()),
@@ -52,7 +52,7 @@ impl CompileCmd {
             format!("{}", sdk_dir.display()),
             format!("{}", ibc_dir.display()),
             format!("{}/../../definitions/mock", root),
-            format!("{}/../../definitions/interchainquery/v1", root),
+            format!("{}/../../definitions/stride/interchainquery/v1", root),
         ];
 
         // List available proto files


### PR DESCRIPTION
Closes #54 

### Description

Add the subfolder `stride` to Stride proto-derived struct used for ICS31 QueryResponse.