### PR TITLE
release: `v0.26.0`

### DIFF
--- a/.changelog/v0.26.0/summary.md
+++ b/.changelog/v0.26.0/summary.md
@@ -1,0 +1,3 @@
+*February 17, 2023*
+
+This release updates tendermint protobuf defintions to `v0.29.0`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## v0.26.0
+
+*February 17, 2023*
+
+This release updates tendermint protobuf defintions to `v0.29.0`.
+
 ## v0.25.0
 
 *February 9th, 2023*

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "ibc-proto"
-version      = "0.25.0"
+version      = "0.26.0"
 authors      = ["Informal Systems <hello@informal.systems>"]
 edition      = "2021"
 license      = "Apache-2.0"
@@ -37,7 +37,7 @@ scale-info = { version = "2.1.2", default-features = false, features = ["derive"
 borsh = {version = "0.10.0", default-features = false, optional = true }
 
 [dependencies.tendermint-proto]
-version          = "0.28"
+version          = "0.29"
 default-features = false
 
 [features]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,6 @@
 #![allow(clippy::large_enum_variant, clippy::derive_partial_eq_without_eq)]
 #![allow(rustdoc::bare_urls)]
 #![forbid(unsafe_code)]
-#![doc(html_root_url = "https://docs.rs/ibc-proto/0.25.0")]
 
 pub mod google;
 pub mod protobuf;


### PR DESCRIPTION
👋, this is a follow-up to the latest `tendermint-rs@v0.29.0` release (https://github.com/informalsystems/tendermint-rs/releases/tag/v0.29.0)!