### PR TITLE
Remove errors for `encode{,_length_delimited}_vec`

### DIFF
--- a/.changelog/unreleased/breaking-changes/73-encode-vec-no-error.md
+++ b/.changelog/unreleased/breaking-changes/73-encode-vec-no-error.md
@@ -1,0 +1,2 @@
+- Remove errors for `encode_vec` and `encode_length_delimited_vec` in
+  `Protobuf` ([#73](https://github.com/cosmos/ibc-proto-rs/issues/73))

--- a/src/protobuf/error.rs
+++ b/src/protobuf/error.rs
@@ -2,7 +2,6 @@ use alloc::format;
 use alloc::string::String;
 use core::fmt::Display;
 use core::format_args;
-use core::num::TryFromIntError;
 
 use flex_error::{define_error, DisplayOnly};
 use prost::{DecodeError, EncodeError};
@@ -25,10 +24,6 @@ define_error! {
         DecodeMessage
             [ DisplayOnly<DecodeError> ]
             | _ | { "error decoding buffer into message" },
-
-        ParseLength
-            [ DisplayOnly<TryFromIntError> ]
-            | _ | { "error parsing encoded length" },
     }
 }
 

--- a/src/protobuf/mod.rs
+++ b/src/protobuf/mod.rs
@@ -63,7 +63,6 @@ use alloc::vec::Vec;
 use core::fmt::Display;
 
 use bytes::Buf;
-use prost::encoding::encoded_len_varint;
 use prost::Message;
 use subtle_encoding::hex;
 
@@ -145,9 +144,8 @@ where
     }
 
     /// Encodes into a Protobuf-encoded `Vec<u8>`.
-    fn encode_vec(&self) -> Result<Vec<u8>, Error> {
-        let mut wire = Vec::with_capacity(self.encoded_len());
-        self.encode(&mut wire).map(|_| wire)
+    fn encode_vec(&self) -> Vec<u8> {
+        self.clone_into().encode_to_vec()
     }
 
     /// Constructor that attempts to decode a Protobuf-encoded instance from a
@@ -160,11 +158,8 @@ where
     }
 
     /// Encode with a length-delimiter to a `Vec<u8>` Protobuf-encoded message.
-    fn encode_length_delimited_vec(&self) -> Result<Vec<u8>, Error> {
-        let len = self.encoded_len();
-        let lenu64 = len.try_into().map_err(Error::parse_length)?;
-        let mut wire = Vec::with_capacity(len + encoded_len_varint(lenu64));
-        self.encode_length_delimited(&mut wire).map(|_| wire)
+    fn encode_length_delimited_vec(&self) -> Vec<u8> {
+        self.clone_into().encode_length_delimited_to_vec()
     }
 
     /// Constructor that attempts to decode a Protobuf-encoded instance with a
@@ -177,7 +172,7 @@ where
     }
 
     fn encode_to_hex_string(&self) -> String {
-        let buf = self.encode_vec().expect("encoding shouldn't fail");
+        let buf = self.encode_vec();
         let encoded = hex::encode(buf);
         String::from_utf8(encoded).expect("hex-encoded string should always be valid UTF-8")
     }


### PR DESCRIPTION
These functions now use the underlying `prost::Message` functions that don't return any errors. The previous code didn't produce any errors anyways as the correct-capacity `Vec` would always be created, but this makes the code more explicit.