### PR TITLE
Update `prost` to v0.12 and `tonic` to v0.10

### DIFF
--- a/.changelog/unreleased/features/145-prost-0.12.md
+++ b/.changelog/unreleased/features/145-prost-0.12.md
@@ -1,0 +1,2 @@
+- Update `prost` to v0.12 and `tonic` to v0.10
+  ([\#145](https://github.com/cosmos/ibc-proto-rs/issues/145))

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,16 +36,15 @@ schemars        = { version = "0.8",  optional = true }
 subtle-encoding = { version = "0.5",  default-features = false }
 base64          = { version = "0.21", default-features = false, features = ["alloc"] }
 flex-error      = { version = "0.4",  default-features = false }
+ics23           = { version = "0.11.0" , default-features = false }
 
-## for codec encode or decode
+## Optional: enabled by the `parity-scale-codec` feature
 parity-scale-codec = { version = "3.0.0", default-features = false, features = ["full"],   optional = true }
 scale-info         = { version = "2.1.2", default-features = false, features = ["derive"], optional = true }
 
-## for borsh encode or decode
-## need tracking anchor-lang and near-sdk-rs borsh version
+## Optional: enabled by the `borsh` feature
+## For borsh encode or decode, needs to track `anchor-lang` and `near-sdk-rs` borsh version
 borsh = { version = "0.10", default-features = false, optional = true }
-
-ics23 = { version = "0.10.3" , default-features = false }
 
 [dependencies.tendermint-proto]
 version          = "0.34"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,9 +28,9 @@ doctest = false
 all-features = true
 
 [dependencies]
-prost           = { version = "0.11", default-features = false }
+prost           = { version = "0.12", default-features = false }
 bytes           = { version = "1.2",  default-features = false }
-tonic           = { version = "0.9",  default-features = false, optional = true }
+tonic           = { version = "0.10",  default-features = false, optional = true }
 serde           = { version = "1.0",  default-features = false }
 schemars        = { version = "0.8",  optional = true }
 subtle-encoding = { version = "0.5",  default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ scale-info         = { version = "2.1.2", default-features = false, features = [
 ## need tracking anchor-lang and near-sdk-rs borsh version
 borsh = { version = "0.10", default-features = false, optional = true }
 
-ics23 = { version = "0.10.2" , default-features = false }
+ics23 = { version = "0.10.3" , default-features = false }
 
 [dependencies.tendermint-proto]
 version          = "0.34"
@@ -61,7 +61,3 @@ server             = ["std", "tonic", "tonic/codegen", "tonic/transport", "tonic
 parity-scale-codec = ["dep:parity-scale-codec", "dep:scale-info"]
 borsh              = ["dep:borsh"]
 proto-descriptor   = []
-
-[patch.crates-io]
-# tendermint-proto = { git = "https://github.com/informalsystems/tendermint-rs", branch = "main" }
-ics23 = { git = "https://github.com/cosmos/ics23", branch = "romac/prost-0.12" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ borsh = { version = "0.10", default-features = false, optional = true }
 ics23 = { version = "0.10.2" , default-features = false }
 
 [dependencies.tendermint-proto]
-version          = "0.33"
+version          = "0.34"
 default-features = false
 
 [features]
@@ -63,5 +63,5 @@ borsh              = ["dep:borsh"]
 proto-descriptor   = []
 
 [patch.crates-io]
-tendermint-proto = { git = "https://github.com/informalsystems/tendermint-rs", branch = "main" }
+# tendermint-proto = { git = "https://github.com/informalsystems/tendermint-rs", branch = "main" }
 ics23 = { git = "https://github.com/cosmos/ics23", branch = "romac/prost-0.12" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ doctest = false
 all-features = true
 
 [dependencies]
-prost           = { version = "0.12", default-features = false }
+prost           = { version = "0.12", default-features = false, features = ["prost-derive"] }
 bytes           = { version = "1.2",  default-features = false }
 tonic           = { version = "0.10",  default-features = false, optional = true }
 serde           = { version = "1.0",  default-features = false }
@@ -61,3 +61,7 @@ server             = ["std", "tonic", "tonic/codegen", "tonic/transport", "tonic
 parity-scale-codec = ["dep:parity-scale-codec", "dep:scale-info"]
 borsh              = ["dep:borsh"]
 proto-descriptor   = []
+
+[patch.crates-io]
+tendermint-proto = { git = "https://github.com/informalsystems/tendermint-rs", branch = "main" }
+ics23 = { git = "https://github.com/cosmos/ics23", branch = "romac/prost-0.12" }

--- a/src/prost/cosmos.auth.v1beta1.rs
+++ b/src/prost/cosmos.auth.v1beta1.rs
@@ -315,7 +315,7 @@ pub mod msg_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).update_params(request).await
+                                <T as Msg>::update_params(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -1165,7 +1165,9 @@ pub mod query_server {
                             request: tonic::Request<super::QueryAccountsRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move { (*inner).accounts(request).await };
+                            let fut = async move {
+                                <T as Query>::accounts(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -1209,7 +1211,9 @@ pub mod query_server {
                             request: tonic::Request<super::QueryAccountRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move { (*inner).account(request).await };
+                            let fut = async move {
+                                <T as Query>::account(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -1256,7 +1260,7 @@ pub mod query_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).account_address_by_id(request).await
+                                <T as Query>::account_address_by_id(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -1299,7 +1303,9 @@ pub mod query_server {
                             request: tonic::Request<super::QueryParamsRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move { (*inner).params(request).await };
+                            let fut = async move {
+                                <T as Query>::params(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -1344,7 +1350,7 @@ pub mod query_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).module_accounts(request).await
+                                <T as Query>::module_accounts(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -1392,7 +1398,7 @@ pub mod query_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).module_account_by_name(request).await
+                                <T as Query>::module_account_by_name(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -1438,7 +1444,7 @@ pub mod query_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).bech32_prefix(request).await
+                                <T as Query>::bech32_prefix(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -1484,7 +1490,7 @@ pub mod query_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).address_bytes_to_string(request).await
+                                <T as Query>::address_bytes_to_string(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -1530,7 +1536,7 @@ pub mod query_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).address_string_to_bytes(request).await
+                                <T as Query>::address_string_to_bytes(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -1576,7 +1582,7 @@ pub mod query_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).account_info(request).await
+                                <T as Query>::account_info(&inner, request).await
                             };
                             Box::pin(fut)
                         }

--- a/src/prost/cosmos.bank.v1beta1.rs
+++ b/src/prost/cosmos.bank.v1beta1.rs
@@ -546,7 +546,9 @@ pub mod msg_server {
                             request: tonic::Request<super::MsgSend>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move { (*inner).send(request).await };
+                            let fut = async move {
+                                <T as Msg>::send(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -588,7 +590,9 @@ pub mod msg_server {
                             request: tonic::Request<super::MsgMultiSend>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move { (*inner).multi_send(request).await };
+                            let fut = async move {
+                                <T as Msg>::multi_send(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -631,7 +635,7 @@ pub mod msg_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).update_params(request).await
+                                <T as Msg>::update_params(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -675,7 +679,7 @@ pub mod msg_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).set_send_enabled(request).await
+                                <T as Msg>::set_send_enabled(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -1686,7 +1690,9 @@ pub mod query_server {
                             request: tonic::Request<super::QueryBalanceRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move { (*inner).balance(request).await };
+                            let fut = async move {
+                                <T as Query>::balance(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -1731,7 +1737,7 @@ pub mod query_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).all_balances(request).await
+                                <T as Query>::all_balances(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -1777,7 +1783,7 @@ pub mod query_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).spendable_balances(request).await
+                                <T as Query>::spendable_balances(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -1826,7 +1832,8 @@ pub mod query_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).spendable_balance_by_denom(request).await
+                                <T as Query>::spendable_balance_by_denom(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -1872,7 +1879,7 @@ pub mod query_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).total_supply(request).await
+                                <T as Query>::total_supply(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -1917,7 +1924,9 @@ pub mod query_server {
                             request: tonic::Request<super::QuerySupplyOfRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move { (*inner).supply_of(request).await };
+                            let fut = async move {
+                                <T as Query>::supply_of(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -1959,7 +1968,9 @@ pub mod query_server {
                             request: tonic::Request<super::QueryParamsRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move { (*inner).params(request).await };
+                            let fut = async move {
+                                <T as Query>::params(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -2004,7 +2015,7 @@ pub mod query_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).denom_metadata(request).await
+                                <T as Query>::denom_metadata(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -2050,7 +2061,7 @@ pub mod query_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).denoms_metadata(request).await
+                                <T as Query>::denoms_metadata(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -2096,7 +2107,7 @@ pub mod query_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).denom_owners(request).await
+                                <T as Query>::denom_owners(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -2142,7 +2153,7 @@ pub mod query_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).send_enabled(request).await
+                                <T as Query>::send_enabled(&inner, request).await
                             };
                             Box::pin(fut)
                         }

--- a/src/prost/cosmos.base.node.v1beta1.rs
+++ b/src/prost/cosmos.base.node.v1beta1.rs
@@ -230,7 +230,9 @@ pub mod service_server {
                             request: tonic::Request<super::ConfigRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move { (*inner).config(request).await };
+                            let fut = async move {
+                                <T as Service>::config(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }

--- a/src/prost/cosmos.base.reflection.v1beta1.rs
+++ b/src/prost/cosmos.base.reflection.v1beta1.rs
@@ -307,7 +307,11 @@ pub mod reflection_service_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).list_all_interfaces(request).await
+                                <T as ReflectionService>::list_all_interfaces(
+                                        &inner,
+                                        request,
+                                    )
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -353,7 +357,11 @@ pub mod reflection_service_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).list_implementations(request).await
+                                <T as ReflectionService>::list_implementations(
+                                        &inner,
+                                        request,
+                                    )
+                                    .await
                             };
                             Box::pin(fut)
                         }

--- a/src/prost/cosmos.base.reflection.v2alpha1.rs
+++ b/src/prost/cosmos.base.reflection.v2alpha1.rs
@@ -682,7 +682,11 @@ pub mod reflection_service_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).get_authn_descriptor(request).await
+                                <T as ReflectionService>::get_authn_descriptor(
+                                        &inner,
+                                        request,
+                                    )
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -728,7 +732,11 @@ pub mod reflection_service_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).get_chain_descriptor(request).await
+                                <T as ReflectionService>::get_chain_descriptor(
+                                        &inner,
+                                        request,
+                                    )
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -774,7 +782,11 @@ pub mod reflection_service_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).get_codec_descriptor(request).await
+                                <T as ReflectionService>::get_codec_descriptor(
+                                        &inner,
+                                        request,
+                                    )
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -825,7 +837,11 @@ pub mod reflection_service_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).get_configuration_descriptor(request).await
+                                <T as ReflectionService>::get_configuration_descriptor(
+                                        &inner,
+                                        request,
+                                    )
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -876,7 +892,11 @@ pub mod reflection_service_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).get_query_services_descriptor(request).await
+                                <T as ReflectionService>::get_query_services_descriptor(
+                                        &inner,
+                                        request,
+                                    )
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -922,7 +942,8 @@ pub mod reflection_service_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).get_tx_descriptor(request).await
+                                <T as ReflectionService>::get_tx_descriptor(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }

--- a/src/prost/cosmos.base.tendermint.v1beta1.rs
+++ b/src/prost/cosmos.base.tendermint.v1beta1.rs
@@ -766,7 +766,7 @@ pub mod service_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).get_node_info(request).await
+                                <T as Service>::get_node_info(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -811,7 +811,9 @@ pub mod service_server {
                             request: tonic::Request<super::GetSyncingRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move { (*inner).get_syncing(request).await };
+                            let fut = async move {
+                                <T as Service>::get_syncing(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -856,7 +858,7 @@ pub mod service_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).get_latest_block(request).await
+                                <T as Service>::get_latest_block(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -902,7 +904,7 @@ pub mod service_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).get_block_by_height(request).await
+                                <T as Service>::get_block_by_height(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -948,7 +950,8 @@ pub mod service_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).get_latest_validator_set(request).await
+                                <T as Service>::get_latest_validator_set(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -996,7 +999,8 @@ pub mod service_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).get_validator_set_by_height(request).await
+                                <T as Service>::get_validator_set_by_height(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -1039,7 +1043,9 @@ pub mod service_server {
                             request: tonic::Request<super::AbciQueryRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move { (*inner).abci_query(request).await };
+                            let fut = async move {
+                                <T as Service>::abci_query(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }

--- a/src/prost/cosmos.gov.v1.rs
+++ b/src/prost/cosmos.gov.v1.rs
@@ -827,7 +827,7 @@ pub mod msg_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).submit_proposal(request).await
+                                <T as Msg>::submit_proposal(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -871,7 +871,7 @@ pub mod msg_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).exec_legacy_content(request).await
+                                <T as Msg>::exec_legacy_content(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -914,7 +914,9 @@ pub mod msg_server {
                             request: tonic::Request<super::MsgVote>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move { (*inner).vote(request).await };
+                            let fut = async move {
+                                <T as Msg>::vote(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -957,7 +959,7 @@ pub mod msg_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).vote_weighted(request).await
+                                <T as Msg>::vote_weighted(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -1000,7 +1002,9 @@ pub mod msg_server {
                             request: tonic::Request<super::MsgDeposit>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move { (*inner).deposit(request).await };
+                            let fut = async move {
+                                <T as Msg>::deposit(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -1043,7 +1047,7 @@ pub mod msg_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).update_params(request).await
+                                <T as Msg>::update_params(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -1764,7 +1768,9 @@ pub mod query_server {
                             request: tonic::Request<super::QueryProposalRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move { (*inner).proposal(request).await };
+                            let fut = async move {
+                                <T as Query>::proposal(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -1808,7 +1814,9 @@ pub mod query_server {
                             request: tonic::Request<super::QueryProposalsRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move { (*inner).proposals(request).await };
+                            let fut = async move {
+                                <T as Query>::proposals(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -1850,7 +1858,9 @@ pub mod query_server {
                             request: tonic::Request<super::QueryVoteRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move { (*inner).vote(request).await };
+                            let fut = async move {
+                                <T as Query>::vote(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -1892,7 +1902,9 @@ pub mod query_server {
                             request: tonic::Request<super::QueryVotesRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move { (*inner).votes(request).await };
+                            let fut = async move {
+                                <T as Query>::votes(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -1934,7 +1946,9 @@ pub mod query_server {
                             request: tonic::Request<super::QueryParamsRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move { (*inner).params(request).await };
+                            let fut = async move {
+                                <T as Query>::params(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -1978,7 +1992,9 @@ pub mod query_server {
                             request: tonic::Request<super::QueryDepositRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move { (*inner).deposit(request).await };
+                            let fut = async move {
+                                <T as Query>::deposit(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -2022,7 +2038,9 @@ pub mod query_server {
                             request: tonic::Request<super::QueryDepositsRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move { (*inner).deposits(request).await };
+                            let fut = async move {
+                                <T as Query>::deposits(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -2067,7 +2085,7 @@ pub mod query_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).tally_result(request).await
+                                <T as Query>::tally_result(&inner, request).await
                             };
                             Box::pin(fut)
                         }

--- a/src/prost/cosmos.gov.v1beta1.rs
+++ b/src/prost/cosmos.gov.v1beta1.rs
@@ -663,7 +663,7 @@ pub mod msg_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).submit_proposal(request).await
+                                <T as Msg>::submit_proposal(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -706,7 +706,9 @@ pub mod msg_server {
                             request: tonic::Request<super::MsgVote>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move { (*inner).vote(request).await };
+                            let fut = async move {
+                                <T as Msg>::vote(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -749,7 +751,7 @@ pub mod msg_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).vote_weighted(request).await
+                                <T as Msg>::vote_weighted(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -792,7 +794,9 @@ pub mod msg_server {
                             request: tonic::Request<super::MsgDeposit>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move { (*inner).deposit(request).await };
+                            let fut = async move {
+                                <T as Msg>::deposit(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -1504,7 +1508,9 @@ pub mod query_server {
                             request: tonic::Request<super::QueryProposalRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move { (*inner).proposal(request).await };
+                            let fut = async move {
+                                <T as Query>::proposal(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -1548,7 +1554,9 @@ pub mod query_server {
                             request: tonic::Request<super::QueryProposalsRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move { (*inner).proposals(request).await };
+                            let fut = async move {
+                                <T as Query>::proposals(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -1590,7 +1598,9 @@ pub mod query_server {
                             request: tonic::Request<super::QueryVoteRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move { (*inner).vote(request).await };
+                            let fut = async move {
+                                <T as Query>::vote(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -1632,7 +1642,9 @@ pub mod query_server {
                             request: tonic::Request<super::QueryVotesRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move { (*inner).votes(request).await };
+                            let fut = async move {
+                                <T as Query>::votes(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -1674,7 +1686,9 @@ pub mod query_server {
                             request: tonic::Request<super::QueryParamsRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move { (*inner).params(request).await };
+                            let fut = async move {
+                                <T as Query>::params(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -1718,7 +1732,9 @@ pub mod query_server {
                             request: tonic::Request<super::QueryDepositRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move { (*inner).deposit(request).await };
+                            let fut = async move {
+                                <T as Query>::deposit(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -1762,7 +1778,9 @@ pub mod query_server {
                             request: tonic::Request<super::QueryDepositsRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move { (*inner).deposits(request).await };
+                            let fut = async move {
+                                <T as Query>::deposits(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -1807,7 +1825,7 @@ pub mod query_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).tally_result(request).await
+                                <T as Query>::tally_result(&inner, request).await
                             };
                             Box::pin(fut)
                         }

--- a/src/prost/cosmos.staking.v1beta1.rs
+++ b/src/prost/cosmos.staking.v1beta1.rs
@@ -1048,7 +1048,7 @@ pub mod msg_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).create_validator(request).await
+                                <T as Msg>::create_validator(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -1092,7 +1092,7 @@ pub mod msg_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).edit_validator(request).await
+                                <T as Msg>::edit_validator(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -1135,7 +1135,9 @@ pub mod msg_server {
                             request: tonic::Request<super::MsgDelegate>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move { (*inner).delegate(request).await };
+                            let fut = async move {
+                                <T as Msg>::delegate(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -1178,7 +1180,7 @@ pub mod msg_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).begin_redelegate(request).await
+                                <T as Msg>::begin_redelegate(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -1221,7 +1223,9 @@ pub mod msg_server {
                             request: tonic::Request<super::MsgUndelegate>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move { (*inner).undelegate(request).await };
+                            let fut = async move {
+                                <T as Msg>::undelegate(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -1266,7 +1270,8 @@ pub mod msg_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).cancel_unbonding_delegation(request).await
+                                <T as Msg>::cancel_unbonding_delegation(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -1310,7 +1315,7 @@ pub mod msg_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).update_params(request).await
+                                <T as Msg>::update_params(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -2455,7 +2460,9 @@ pub mod query_server {
                             request: tonic::Request<super::QueryValidatorsRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move { (*inner).validators(request).await };
+                            let fut = async move {
+                                <T as Query>::validators(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -2499,7 +2506,9 @@ pub mod query_server {
                             request: tonic::Request<super::QueryValidatorRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move { (*inner).validator(request).await };
+                            let fut = async move {
+                                <T as Query>::validator(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -2547,7 +2556,7 @@ pub mod query_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).validator_delegations(request).await
+                                <T as Query>::validator_delegations(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -2596,7 +2605,11 @@ pub mod query_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).validator_unbonding_delegations(request).await
+                                <T as Query>::validator_unbonding_delegations(
+                                        &inner,
+                                        request,
+                                    )
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -2641,7 +2654,9 @@ pub mod query_server {
                             request: tonic::Request<super::QueryDelegationRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move { (*inner).delegation(request).await };
+                            let fut = async move {
+                                <T as Query>::delegation(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -2688,7 +2703,7 @@ pub mod query_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).unbonding_delegation(request).await
+                                <T as Query>::unbonding_delegation(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -2737,7 +2752,7 @@ pub mod query_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).delegator_delegations(request).await
+                                <T as Query>::delegator_delegations(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -2786,7 +2801,11 @@ pub mod query_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).delegator_unbonding_delegations(request).await
+                                <T as Query>::delegator_unbonding_delegations(
+                                        &inner,
+                                        request,
+                                    )
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -2832,7 +2851,7 @@ pub mod query_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).redelegations(request).await
+                                <T as Query>::redelegations(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -2880,7 +2899,7 @@ pub mod query_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).delegator_validators(request).await
+                                <T as Query>::delegator_validators(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -2928,7 +2947,7 @@ pub mod query_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).delegator_validator(request).await
+                                <T as Query>::delegator_validator(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -2974,7 +2993,7 @@ pub mod query_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).historical_info(request).await
+                                <T as Query>::historical_info(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -3017,7 +3036,9 @@ pub mod query_server {
                             request: tonic::Request<super::QueryPoolRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move { (*inner).pool(request).await };
+                            let fut = async move {
+                                <T as Query>::pool(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -3059,7 +3080,9 @@ pub mod query_server {
                             request: tonic::Request<super::QueryParamsRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move { (*inner).params(request).await };
+                            let fut = async move {
+                                <T as Query>::params(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }

--- a/src/prost/cosmos.tx.v1beta1.rs
+++ b/src/prost/cosmos.tx.v1beta1.rs
@@ -1112,7 +1112,9 @@ pub mod service_server {
                             request: tonic::Request<super::SimulateRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move { (*inner).simulate(request).await };
+                            let fut = async move {
+                                <T as Service>::simulate(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -1154,7 +1156,9 @@ pub mod service_server {
                             request: tonic::Request<super::GetTxRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move { (*inner).get_tx(request).await };
+                            let fut = async move {
+                                <T as Service>::get_tx(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -1199,7 +1203,7 @@ pub mod service_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).broadcast_tx(request).await
+                                <T as Service>::broadcast_tx(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -1245,7 +1249,7 @@ pub mod service_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).get_txs_event(request).await
+                                <T as Service>::get_txs_event(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -1291,7 +1295,7 @@ pub mod service_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).get_block_with_txs(request).await
+                                <T as Service>::get_block_with_txs(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -1334,7 +1338,9 @@ pub mod service_server {
                             request: tonic::Request<super::TxDecodeRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move { (*inner).tx_decode(request).await };
+                            let fut = async move {
+                                <T as Service>::tx_decode(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -1376,7 +1382,9 @@ pub mod service_server {
                             request: tonic::Request<super::TxEncodeRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move { (*inner).tx_encode(request).await };
+                            let fut = async move {
+                                <T as Service>::tx_encode(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -1421,7 +1429,7 @@ pub mod service_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).tx_encode_amino(request).await
+                                <T as Service>::tx_encode_amino(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -1467,7 +1475,7 @@ pub mod service_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).tx_decode_amino(request).await
+                                <T as Service>::tx_decode_amino(&inner, request).await
                             };
                             Box::pin(fut)
                         }

--- a/src/prost/cosmos.upgrade.v1beta1.rs
+++ b/src/prost/cosmos.upgrade.v1beta1.rs
@@ -394,7 +394,7 @@ pub mod msg_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).software_upgrade(request).await
+                                <T as Msg>::software_upgrade(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -438,7 +438,7 @@ pub mod msg_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).cancel_upgrade(request).await
+                                <T as Msg>::cancel_upgrade(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -998,7 +998,7 @@ pub mod query_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).current_plan(request).await
+                                <T as Query>::current_plan(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -1044,7 +1044,7 @@ pub mod query_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).applied_plan(request).await
+                                <T as Query>::applied_plan(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -1093,7 +1093,8 @@ pub mod query_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).upgraded_consensus_state(request).await
+                                <T as Query>::upgraded_consensus_state(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -1139,7 +1140,7 @@ pub mod query_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).module_versions(request).await
+                                <T as Query>::module_versions(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -1184,7 +1185,9 @@ pub mod query_server {
                             request: tonic::Request<super::QueryAuthorityRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move { (*inner).authority(request).await };
+                            let fut = async move {
+                                <T as Query>::authority(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }

--- a/src/prost/google.api.rs
+++ b/src/prost/google.api.rs
@@ -1,5 +1,5 @@
 /// Defines the HTTP configuration for an API service. It contains a list of
-/// \[HttpRule][google.api.HttpRule\], each specifying the mapping of an RPC method
+/// [HttpRule][google.api.HttpRule], each specifying the mapping of an RPC method
 /// to one or more HTTP REST API methods.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -26,7 +26,7 @@ pub struct Http {
 /// APIs](<https://github.com/googleapis/googleapis>),
 /// [Cloud Endpoints](<https://cloud.google.com/endpoints>), [gRPC
 /// Gateway](<https://github.com/grpc-ecosystem/grpc-gateway>),
-/// and \[Envoy\](<https://github.com/envoyproxy/envoy>) proxy support this feature
+/// and [Envoy](<https://github.com/envoyproxy/envoy>) proxy support this feature
 /// and use it for large scale production services.
 ///
 /// `HttpRule` defines the schema of the gRPC/REST mapping. The mapping specifies
@@ -187,26 +187,26 @@ pub struct Http {
 /// 1. Leaf request fields (recursive expansion nested messages in the request
 ///     message) are classified into three categories:
 ///     - Fields referred by the path template. They are passed via the URL path.
-///     - Fields referred by the \[HttpRule.body][google.api.HttpRule.body\]. They
+///     - Fields referred by the [HttpRule.body][google.api.HttpRule.body]. They
 ///     are passed via the HTTP
 ///       request body.
 ///     - All other fields are passed via the URL query parameters, and the
 ///       parameter name is the field path in the request message. A repeated
 ///       field can be represented as multiple query parameters under the same
 ///       name.
-///   2. If \[HttpRule.body][google.api.HttpRule.body\] is "*", there is no URL
+///   2. If [HttpRule.body][google.api.HttpRule.body] is "*", there is no URL
 ///   query parameter, all fields
 ///      are passed via URL path and HTTP request body.
-///   3. If \[HttpRule.body][google.api.HttpRule.body\] is omitted, there is no HTTP
+///   3. If [HttpRule.body][google.api.HttpRule.body] is omitted, there is no HTTP
 ///   request body, all
 ///      fields are passed via URL path and URL query parameters.
 ///
 /// ### Path template syntax
 ///
-///      Template = "/" Segments [ Verb ] ;
+///      Template = "/" Segments \[ Verb \] ;
 ///      Segments = Segment { "/" Segment } ;
 ///      Segment  = "*" | "**" | LITERAL | Variable ;
-///      Variable = "{" FieldPath [ "=" Segments ] "}" ;
+///      Variable = "{" FieldPath \[ "=" Segments \] "}" ;
 ///      FieldPath = IDENT { "." IDENT } ;
 ///      Verb     = ":" LITERAL ;
 ///
@@ -295,7 +295,7 @@ pub struct Http {
 pub struct HttpRule {
     /// Selects a method to which this rule applies.
     ///
-    /// Refer to \[selector][google.api.DocumentationRule.selector\] for syntax
+    /// Refer to [selector][google.api.DocumentationRule.selector] for syntax
     /// details.
     #[prost(string, tag = "1")]
     pub selector: ::prost::alloc::string::String,

--- a/src/prost/google.protobuf.rs
+++ b/src/prost/google.protobuf.rs
@@ -1237,7 +1237,7 @@ pub mod uninterpreted_option {
     /// The name of the uninterpreted option.  Each string represents a segment in
     /// a dot-separated name.  is_extension is true iff a segment represents an
     /// extension (denoted with parentheses in options specs in .proto files).
-    /// E.g.,{ ["foo", false], ["bar.baz", true], ["moo", false] } represents
+    /// E.g.,{ \["foo", false\], \["bar.baz", true\], \["moo", false\] } represents
     /// "foo.(bar.baz).moo".
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
@@ -1535,11 +1535,11 @@ pub struct SourceCodeInfo {
     ///    a       bc     de  f  ghi
     /// We have the following locations:
     ///    span   path               represents
-    ///    [a,i)  [ 4, 0, 2, 0 ]     The whole field definition.
-    ///    [a,b)  [ 4, 0, 2, 0, 4 ]  The label (optional).
-    ///    [c,d)  [ 4, 0, 2, 0, 5 ]  The type (string).
-    ///    [e,f)  [ 4, 0, 2, 0, 1 ]  The name (foo).
-    ///    [g,h)  [ 4, 0, 2, 0, 3 ]  The number (1).
+    ///    \[a,i)  [ 4, 0, 2, 0 \]     The whole field definition.
+    ///    \[a,b)  [ 4, 0, 2, 0, 4 \]  The label (optional).
+    ///    \[c,d)  [ 4, 0, 2, 0, 5 \]  The type (string).
+    ///    \[e,f)  [ 4, 0, 2, 0, 1 \]  The name (foo).
+    ///    \[g,h)  [ 4, 0, 2, 0, 3 \]  The number (1).
     ///
     /// Notes:
     /// - A location may refer to a repeated field itself (i.e. not to any
@@ -1577,7 +1577,7 @@ pub mod source_code_info {
         /// Each element is a field number or an index.  They form a path from
         /// the root FileDescriptorProto to the place where the definition occurs.
         /// For example, this path:
-        ///    [ 4, 3, 2, 7, 1 ]
+        ///    \[ 4, 3, 2, 7, 1 \]
         /// refers to:
         ///    file.message_type(3)  // 4, 3
         ///        .field(7)         // 2, 7
@@ -1591,7 +1591,7 @@ pub mod source_code_info {
         ///
         /// Thus, the above path gives the location of a field name.  If we removed
         /// the last element:
-        ///    [ 4, 3, 2, 7 ]
+        ///    \[ 4, 3, 2, 7 \]
         /// this path refers to the whole field declaration (from the beginning
         /// of the label to the terminating semicolon).
         #[prost(int32, repeated, tag = "1")]
@@ -1822,7 +1822,7 @@ pub mod generated_code_info {
 /// If the embedded message type is well-known and has a custom JSON
 /// representation, that representation will be embedded adding a field
 /// `value` which holds the custom JSON in addition to the `@type`
-/// field. Example (for message \[google.protobuf.Duration][\]):
+/// field. Example (for message [google.protobuf.Duration][]):
 ///
 ///      {
 ///        "@type": "type.googleapis.com/google.protobuf.Duration",
@@ -1847,7 +1847,7 @@ pub struct Any {
     /// server that maps type URLs to message definitions as follows:
     ///
     /// * If no scheme is provided, `https` is assumed.
-    /// * An HTTP GET on the URL must yield a \[google.protobuf.Type][\]
+    /// * An HTTP GET on the URL must yield a [google.protobuf.Type][]
     ///    value in binary format, or produce an error.
     /// * Applications are allowed to cache lookup results based on the
     ///    URL, or have them precompiled into a binary to avoid any
@@ -1950,12 +1950,12 @@ pub struct Any {
 ///
 /// In JavaScript, one can convert a Date object to this format using the
 /// standard
-/// \[toISOString()\](<https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString>)
+/// [toISOString()](<https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString>)
 /// method. In Python, a standard `datetime.datetime` object can be converted
 /// to this format using
-/// \[`strftime`\](<https://docs.python.org/2/library/time.html#time.strftime>) with
+/// [`strftime`](<https://docs.python.org/2/library/time.html#time.strftime>) with
 /// the time format spec '%Y-%m-%dT%H:%M:%S.%fZ'. Likewise, in Java, one can use
-/// the Joda Time's \[`ISODateTimeFormat.dateTime()`\](
+/// the Joda Time's [`ISODateTimeFormat.dateTime()`](
 /// <http://joda-time.sourceforge.net/apidocs/org/joda/time/format/ISODateTimeFormat.html#dateTime(>)
 /// ) to obtain a formatter capable of generating timestamps in this format.
 ///

--- a/src/prost/ibc.applications.fee.v1.rs
+++ b/src/prost/ibc.applications.fee.v1.rs
@@ -504,7 +504,7 @@ pub mod msg_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).register_payee(request).await
+                                <T as Msg>::register_payee(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -550,7 +550,8 @@ pub mod msg_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).register_counterparty_payee(request).await
+                                <T as Msg>::register_counterparty_payee(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -594,7 +595,7 @@ pub mod msg_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).pay_packet_fee(request).await
+                                <T as Msg>::pay_packet_fee(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -638,7 +639,7 @@ pub mod msg_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).pay_packet_fee_async(request).await
+                                <T as Msg>::pay_packet_fee_async(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -1572,7 +1573,7 @@ pub mod query_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).incentivized_packets(request).await
+                                <T as Query>::incentivized_packets(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -1620,7 +1621,7 @@ pub mod query_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).incentivized_packet(request).await
+                                <T as Query>::incentivized_packet(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -1669,7 +1670,11 @@ pub mod query_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).incentivized_packets_for_channel(request).await
+                                <T as Query>::incentivized_packets_for_channel(
+                                        &inner,
+                                        request,
+                                    )
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -1715,7 +1720,7 @@ pub mod query_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).total_recv_fees(request).await
+                                <T as Query>::total_recv_fees(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -1761,7 +1766,7 @@ pub mod query_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).total_ack_fees(request).await
+                                <T as Query>::total_ack_fees(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -1807,7 +1812,7 @@ pub mod query_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).total_timeout_fees(request).await
+                                <T as Query>::total_timeout_fees(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -1850,7 +1855,9 @@ pub mod query_server {
                             request: tonic::Request<super::QueryPayeeRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move { (*inner).payee(request).await };
+                            let fut = async move {
+                                <T as Query>::payee(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -1895,7 +1902,7 @@ pub mod query_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).counterparty_payee(request).await
+                                <T as Query>::counterparty_payee(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -1943,7 +1950,7 @@ pub mod query_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).fee_enabled_channels(request).await
+                                <T as Query>::fee_enabled_channels(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -1989,7 +1996,7 @@ pub mod query_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).fee_enabled_channel(request).await
+                                <T as Query>::fee_enabled_channel(&inner, request).await
                             };
                             Box::pin(fut)
                         }

--- a/src/prost/ibc.applications.interchain_accounts.controller.v1.rs
+++ b/src/prost/ibc.applications.interchain_accounts.controller.v1.rs
@@ -320,7 +320,8 @@ pub mod msg_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).register_interchain_account(request).await
+                                <T as Msg>::register_interchain_account(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -363,7 +364,9 @@ pub mod msg_server {
                             request: tonic::Request<super::MsgSendTx>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move { (*inner).send_tx(request).await };
+                            let fut = async move {
+                                <T as Msg>::send_tx(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -747,7 +750,7 @@ pub mod query_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).interchain_account(request).await
+                                <T as Query>::interchain_account(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -790,7 +793,9 @@ pub mod query_server {
                             request: tonic::Request<super::QueryParamsRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move { (*inner).params(request).await };
+                            let fut = async move {
+                                <T as Query>::params(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }

--- a/src/prost/ibc.applications.interchain_accounts.host.v1.rs
+++ b/src/prost/ibc.applications.interchain_accounts.host.v1.rs
@@ -257,7 +257,9 @@ pub mod query_server {
                             request: tonic::Request<super::QueryParamsRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move { (*inner).params(request).await };
+                            let fut = async move {
+                                <T as Query>::params(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }

--- a/src/prost/ibc.applications.transfer.v1.rs
+++ b/src/prost/ibc.applications.transfer.v1.rs
@@ -273,7 +273,9 @@ pub mod msg_server {
                             request: tonic::Request<super::MsgTransfer>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move { (*inner).transfer(request).await };
+                            let fut = async move {
+                                <T as Msg>::transfer(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -439,7 +441,7 @@ pub struct QueryParamsResponse {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QueryDenomHashRequest {
-    /// The denomination trace `(\[port_id]/[channel_id])+/[denom\]`
+    /// The denomination trace (\[port_id\]/[channel_id])+/\[denom\]
     #[prost(string, tag = "1")]
     pub trace: ::prost::alloc::string::String,
 }
@@ -907,7 +909,9 @@ pub mod query_server {
                             request: tonic::Request<super::QueryDenomTraceRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move { (*inner).denom_trace(request).await };
+                            let fut = async move {
+                                <T as Query>::denom_trace(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -952,7 +956,7 @@ pub mod query_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).denom_traces(request).await
+                                <T as Query>::denom_traces(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -995,7 +999,9 @@ pub mod query_server {
                             request: tonic::Request<super::QueryParamsRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move { (*inner).params(request).await };
+                            let fut = async move {
+                                <T as Query>::params(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -1039,7 +1045,9 @@ pub mod query_server {
                             request: tonic::Request<super::QueryDenomHashRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move { (*inner).denom_hash(request).await };
+                            let fut = async move {
+                                <T as Query>::denom_hash(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -1084,7 +1092,7 @@ pub mod query_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).escrow_address(request).await
+                                <T as Query>::escrow_address(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -1132,7 +1140,7 @@ pub mod query_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).total_escrow_for_denom(request).await
+                                <T as Query>::total_escrow_for_denom(&inner, request).await
                             };
                             Box::pin(fut)
                         }

--- a/src/prost/ibc.applications.transfer.v1.rs
+++ b/src/prost/ibc.applications.transfer.v1.rs
@@ -441,7 +441,7 @@ pub struct QueryParamsResponse {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QueryDenomHashRequest {
-    /// The denomination trace (\[port_id\]/[channel_id])+/\[denom\]
+    /// The denomination trace `([port_id]/[channel_id])+/[denom]`
     #[prost(string, tag = "1")]
     pub trace: ::prost::alloc::string::String,
 }

--- a/src/prost/ibc.core.channel.v1.rs
+++ b/src/prost/ibc.core.channel.v1.rs
@@ -1103,7 +1103,7 @@ pub mod msg_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).channel_open_init(request).await
+                                <T as Msg>::channel_open_init(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -1147,7 +1147,7 @@ pub mod msg_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).channel_open_try(request).await
+                                <T as Msg>::channel_open_try(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -1191,7 +1191,7 @@ pub mod msg_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).channel_open_ack(request).await
+                                <T as Msg>::channel_open_ack(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -1237,7 +1237,7 @@ pub mod msg_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).channel_open_confirm(request).await
+                                <T as Msg>::channel_open_confirm(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -1281,7 +1281,7 @@ pub mod msg_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).channel_close_init(request).await
+                                <T as Msg>::channel_close_init(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -1327,7 +1327,7 @@ pub mod msg_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).channel_close_confirm(request).await
+                                <T as Msg>::channel_close_confirm(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -1370,7 +1370,9 @@ pub mod msg_server {
                             request: tonic::Request<super::MsgRecvPacket>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move { (*inner).recv_packet(request).await };
+                            let fut = async move {
+                                <T as Msg>::recv_packet(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -1412,7 +1414,9 @@ pub mod msg_server {
                             request: tonic::Request<super::MsgTimeout>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move { (*inner).timeout(request).await };
+                            let fut = async move {
+                                <T as Msg>::timeout(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -1455,7 +1459,7 @@ pub mod msg_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).timeout_on_close(request).await
+                                <T as Msg>::timeout_on_close(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -1499,7 +1503,7 @@ pub mod msg_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).acknowledgement(request).await
+                                <T as Msg>::acknowledgement(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -2662,7 +2666,9 @@ pub mod query_server {
                             request: tonic::Request<super::QueryChannelRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move { (*inner).channel(request).await };
+                            let fut = async move {
+                                <T as Query>::channel(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -2706,7 +2712,9 @@ pub mod query_server {
                             request: tonic::Request<super::QueryChannelsRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move { (*inner).channels(request).await };
+                            let fut = async move {
+                                <T as Query>::channels(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -2753,7 +2761,7 @@ pub mod query_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).connection_channels(request).await
+                                <T as Query>::connection_channels(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -2801,7 +2809,7 @@ pub mod query_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).channel_client_state(request).await
+                                <T as Query>::channel_client_state(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -2850,7 +2858,7 @@ pub mod query_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).channel_consensus_state(request).await
+                                <T as Query>::channel_consensus_state(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -2896,7 +2904,7 @@ pub mod query_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).packet_commitment(request).await
+                                <T as Query>::packet_commitment(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -2942,7 +2950,7 @@ pub mod query_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).packet_commitments(request).await
+                                <T as Query>::packet_commitments(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -2988,7 +2996,7 @@ pub mod query_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).packet_receipt(request).await
+                                <T as Query>::packet_receipt(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -3037,7 +3045,7 @@ pub mod query_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).packet_acknowledgement(request).await
+                                <T as Query>::packet_acknowledgement(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -3086,7 +3094,7 @@ pub mod query_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).packet_acknowledgements(request).await
+                                <T as Query>::packet_acknowledgements(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -3132,7 +3140,7 @@ pub mod query_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).unreceived_packets(request).await
+                                <T as Query>::unreceived_packets(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -3178,7 +3186,7 @@ pub mod query_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).unreceived_acks(request).await
+                                <T as Query>::unreceived_acks(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -3226,7 +3234,7 @@ pub mod query_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).next_sequence_receive(request).await
+                                <T as Query>::next_sequence_receive(&inner, request).await
                             };
                             Box::pin(fut)
                         }

--- a/src/prost/ibc.core.client.v1.rs
+++ b/src/prost/ibc.core.client.v1.rs
@@ -615,7 +615,7 @@ pub mod msg_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).create_client(request).await
+                                <T as Msg>::create_client(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -659,7 +659,7 @@ pub mod msg_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).update_client(request).await
+                                <T as Msg>::update_client(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -703,7 +703,7 @@ pub mod msg_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).upgrade_client(request).await
+                                <T as Msg>::upgrade_client(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -749,7 +749,7 @@ pub mod msg_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).submit_misbehaviour(request).await
+                                <T as Msg>::submit_misbehaviour(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -1556,7 +1556,7 @@ pub mod query_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).client_state(request).await
+                                <T as Query>::client_state(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -1602,7 +1602,7 @@ pub mod query_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).client_states(request).await
+                                <T as Query>::client_states(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -1648,7 +1648,7 @@ pub mod query_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).consensus_state(request).await
+                                <T as Query>::consensus_state(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -1694,7 +1694,7 @@ pub mod query_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).consensus_states(request).await
+                                <T as Query>::consensus_states(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -1743,7 +1743,7 @@ pub mod query_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).consensus_state_heights(request).await
+                                <T as Query>::consensus_state_heights(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -1789,7 +1789,7 @@ pub mod query_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).client_status(request).await
+                                <T as Query>::client_status(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -1835,7 +1835,7 @@ pub mod query_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).client_params(request).await
+                                <T as Query>::client_params(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -1883,7 +1883,7 @@ pub mod query_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).upgraded_client_state(request).await
+                                <T as Query>::upgraded_client_state(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -1932,7 +1932,8 @@ pub mod query_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).upgraded_consensus_state(request).await
+                                <T as Query>::upgraded_consensus_state(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }

--- a/src/prost/ibc.core.connection.v1.rs
+++ b/src/prost/ibc.core.connection.v1.rs
@@ -658,7 +658,7 @@ pub mod msg_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).connection_open_init(request).await
+                                <T as Msg>::connection_open_init(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -702,7 +702,7 @@ pub mod msg_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).connection_open_try(request).await
+                                <T as Msg>::connection_open_try(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -746,7 +746,7 @@ pub mod msg_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).connection_open_ack(request).await
+                                <T as Msg>::connection_open_ack(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -792,7 +792,7 @@ pub mod msg_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).connection_open_confirm(request).await
+                                <T as Msg>::connection_open_confirm(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -1439,7 +1439,9 @@ pub mod query_server {
                             request: tonic::Request<super::QueryConnectionRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move { (*inner).connection(request).await };
+                            let fut = async move {
+                                <T as Query>::connection(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -1483,7 +1485,9 @@ pub mod query_server {
                             request: tonic::Request<super::QueryConnectionsRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move { (*inner).connections(request).await };
+                            let fut = async move {
+                                <T as Query>::connections(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -1528,7 +1532,7 @@ pub mod query_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).client_connections(request).await
+                                <T as Query>::client_connections(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -1577,7 +1581,7 @@ pub mod query_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).connection_client_state(request).await
+                                <T as Query>::connection_client_state(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -1626,7 +1630,8 @@ pub mod query_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).connection_consensus_state(request).await
+                                <T as Query>::connection_consensus_state(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -1672,7 +1677,7 @@ pub mod query_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).connection_params(request).await
+                                <T as Query>::connection_params(&inner, request).await
                             };
                             Box::pin(fut)
                         }

--- a/src/prost/ibc.lightclients.tendermint.v1.rs
+++ b/src/prost/ibc.lightclients.tendermint.v1.rs
@@ -44,7 +44,7 @@ pub struct ClientState {
     /// chained proof. NOTE: ClientState must stored under
     /// `{upgradePath}/{upgradeHeight}/clientState` ConsensusState must be stored
     /// under `{upgradepath}/{upgradeHeight}/consensusState` For SDK chains using
-    /// the default upgrade module, upgrade_path should be []string{"upgrade",
+    /// the default upgrade module, upgrade_path should be \[\]string{"upgrade",
     /// "upgradedIBCState"}`
     #[prost(string, repeated, tag = "9")]
     pub upgrade_path: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,

--- a/src/prost/interchain_security.ccv.consumer.v1.rs
+++ b/src/prost/interchain_security.ccv.consumer.v1.rs
@@ -491,7 +491,8 @@ pub mod query_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).query_next_fee_distribution(request).await
+                                <T as Query>::query_next_fee_distribution(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -535,7 +536,7 @@ pub mod query_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).query_params(request).await
+                                <T as Query>::query_params(&inner, request).await
                             };
                             Box::pin(fut)
                         }

--- a/src/prost/interchain_security.ccv.provider.v1.rs
+++ b/src/prost/interchain_security.ccv.provider.v1.rs
@@ -300,7 +300,7 @@ pub mod msg_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).assign_consumer_key(request).await
+                                <T as Msg>::assign_consumer_key(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -348,7 +348,8 @@ pub mod msg_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).register_consumer_reward_denom(request).await
+                                <T as Msg>::register_consumer_reward_denom(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -1479,7 +1480,7 @@ pub mod query_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).query_consumer_genesis(request).await
+                                <T as Query>::query_consumer_genesis(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -1525,7 +1526,7 @@ pub mod query_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).query_consumer_chains(request).await
+                                <T as Query>::query_consumer_chains(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -1574,7 +1575,8 @@ pub mod query_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).query_consumer_chain_starts(request).await
+                                <T as Query>::query_consumer_chain_starts(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -1623,7 +1625,8 @@ pub mod query_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).query_consumer_chain_stops(request).await
+                                <T as Query>::query_consumer_chain_stops(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -1672,7 +1675,8 @@ pub mod query_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).query_validator_consumer_addr(request).await
+                                <T as Query>::query_validator_consumer_addr(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -1721,7 +1725,8 @@ pub mod query_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).query_validator_provider_addr(request).await
+                                <T as Query>::query_validator_provider_addr(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -1767,7 +1772,7 @@ pub mod query_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).query_throttle_state(request).await
+                                <T as Query>::query_throttle_state(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -1816,7 +1821,11 @@ pub mod query_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).query_throttled_consumer_packet_data(request).await
+                                <T as Query>::query_throttled_consumer_packet_data(
+                                        &inner,
+                                        request,
+                                    )
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -1865,8 +1874,10 @@ pub mod query_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner)
-                                    .query_registered_consumer_reward_denoms(request)
+                                <T as Query>::query_registered_consumer_reward_denoms(
+                                        &inner,
+                                        request,
+                                    )
                                     .await
                             };
                             Box::pin(fut)

--- a/src/prost/stride.interchainquery.v1.rs
+++ b/src/prost/stride.interchainquery.v1.rs
@@ -255,7 +255,7 @@ pub mod msg_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).submit_query_response(request).await
+                                <T as Msg>::submit_query_response(&inner, request).await
                             };
                             Box::pin(fut)
                         }

--- a/tools/proto-compiler/Cargo.toml
+++ b/tools/proto-compiler/Cargo.toml
@@ -7,10 +7,10 @@ publish      = false
 rust-version = "1.60"
 
 [dependencies]
-git2        = "0.17"
-prost-build = "0.11"
+git2        = "0.18"
+prost-build = "0.12"
 walkdir     = "2.3"
 argh        = "0.1"
-tonic       = "0.9"
-tonic-build = "0.9"
+tonic       = "0.10"
+tonic-build = "0.10"
 similar     = "2.2"

--- a/tools/proto-compiler/src/cmd/compile.rs
+++ b/tools/proto-compiler/src/cmd/compile.rs
@@ -228,8 +228,8 @@ impl CompileCmd {
             (
                 "ibc.applications.transfer.v1.rs",
                 &[(
-                    "The denomination trace (\\[port_id]/[channel_id])+/[denom\\]",
-                    "The denomination trace `(\\[port_id]/[channel_id])+/[denom\\]`",
+                    "The denomination trace (\\[port_id\\]/[channel_id])+/\\[denom\\]",
+                    "The denomination trace `([port_id]/[channel_id])+/[denom]`",
                 )],
             ),
         ];


### PR DESCRIPTION
Closes: #145

## Blocked by

- [x] `tendermint-proto` release with `prost` v0.12
- [x] `ics23` release with `prost` v0.12 (https://github.com/cosmos/ics23/pull/205)