### PR TITLE
fix: restore `#[no_std]` attribute for `no_std` compatibility

### DIFF
--- a/.changelog/unreleased/bug-fixes/171-restore-no-std-attribute.md
+++ b/.changelog/unreleased/bug-fixes/171-restore-no-std-attribute.md
@@ -1,0 +1,2 @@
+- Fix `#[no_std]` attribute removal and add `informalsystems-pbjson/std` dependency
+  for `std` feature ([#171](https://github.com/cosmos/ibc-proto-rs/issues/171)).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ serde_json = "1.0.107"
 
 [features]
 default            = ["std", "client"]
-std                = ["prost/std", "bytes/std", "subtle-encoding/std", "base64/std", "flex-error/std", "ics23/std"]
+std                = ["prost/std", "bytes/std", "subtle-encoding/std", "base64/std", "flex-error/std", "ics23/std", "informalsystems-pbjson/std"]
 serde              = ["dep:serde", "ics23/serde", "informalsystems-pbjson"]
 client             = ["std", "dep:tonic", "tonic/codegen", "tonic/transport", "tonic/prost"]
 json-schema        = ["std", "serde", "dep:schemars"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,11 +2,8 @@
 
 // Todo: automate the creation of this module setup based on the dots in the filenames.
 // This module setup is necessary because the generated code contains "super::" calls for dependencies.
-
-#![cfg_attr(
-    not(feature = "serde"),
-    deny(warnings, trivial_casts, trivial_numeric_casts, unused_import_braces)
-)]
+#![cfg_attr(not(feature = "std"), no_std)]
+#![deny(warnings, trivial_casts, trivial_numeric_casts, unused_import_braces)]
 #![allow(clippy::large_enum_variant, clippy::derive_partial_eq_without_eq)]
 #![allow(rustdoc::bare_urls)]
 #![forbid(unsafe_code)]

--- a/src/prost/google.protobuf.serde.rs
+++ b/src/prost/google.protobuf.serde.rs
@@ -4828,7 +4828,7 @@ impl serde::Serialize for UninterpretedOption {
             struct_ser.serialize_field("doubleValue", v)?;
         }
         if let Some(v) = self.string_value.as_ref() {
-            struct_ser.serialize_field("stringValue", pbjson::private::base64::encode(&v).as_str())?;
+            struct_ser.serialize_field("stringValue", pbjson::private::base64::encode(v).as_str())?;
         }
         if let Some(v) = self.aggregate_value.as_ref() {
             struct_ser.serialize_field("aggregateValue", v)?;

--- a/src/prost/ibc.core.channel.v1.serde.rs
+++ b/src/prost/ibc.core.channel.v1.serde.rs
@@ -13,7 +13,7 @@ impl serde::Serialize for Acknowledgement {
         if let Some(v) = self.response.as_ref() {
             match v {
                 acknowledgement::Response::Result(v) => {
-                    struct_ser.serialize_field("result", pbjson::private::base64::encode(&v).as_str())?;
+                    struct_ser.serialize_field("result", pbjson::private::base64::encode(v).as_str())?;
                 }
                 acknowledgement::Response::Error(v) => {
                     struct_ser.serialize_field("error", v)?;


### PR DESCRIPTION
### Description

In PR #166, the `#[no_std]` attribute was inadvertently removed. 
Additionally, we overlooked adding the `informalsystems-pbjson/std` dependency for the `std` feature.