### PR TITLE
Use the v0.34 definition of `tendermint.abci.Event` which does not enforce valid UTF-8 data

### DIFF
--- a/.changelog/unreleased/breaking-changes/181-event-attribute-bytes.md
+++ b/.changelog/unreleased/breaking-changes/181-event-attribute-bytes.md
@@ -1,0 +1,10 @@
+- Use the v0.34 definition of `abci.Event` which does not enforce 
+  valid UTF-8 data for its `key` and `value` attributes, specifying 
+  them as `bytes` instead of `string`. ([#180](https://github.com/cosmos/ibc-proto-rs/issues/180))
+
+  This is required, because ibc-go emits event attributes which are not valid UTF-8,
+  so we need to use this definition to be able to parse them.
+
+  In Protobuf, `bytes` and `string` are wire-compatible, so doing this strictly increases the amount fo data we can parse.
+
+  See this Hermes PR for background information: https://github.com/informalsystems/hermes/pull/3768

--- a/src/prost/cosmos.base.abci.v1beta1.rs
+++ b/src/prost/cosmos.base.abci.v1beta1.rs
@@ -49,7 +49,7 @@ pub struct TxResponse {
     ///
     /// Since: cosmos-sdk 0.42.11, 0.44.5, 0.45
     #[prost(message, repeated, tag = "13")]
-    pub events: ::prost::alloc::vec::Vec<::tendermint_proto::abci::Event>,
+    pub events: ::prost::alloc::vec::Vec<::tendermint_proto::v0_34::abci::Event>,
 }
 impl ::prost::Name for TxResponse {
     const NAME: &'static str = "TxResponse";
@@ -147,7 +147,7 @@ pub struct Result {
     /// Events contains a slice of Event objects that were emitted during message
     /// or handler execution.
     #[prost(message, repeated, tag = "3")]
-    pub events: ::prost::alloc::vec::Vec<::tendermint_proto::abci::Event>,
+    pub events: ::prost::alloc::vec::Vec<::tendermint_proto::v0_34::abci::Event>,
     /// msg_responses contains the Msg handler responses type packed in Anys.
     ///
     /// Since: cosmos-sdk 0.46

--- a/tools/proto-compiler/src/cmd/compile.rs
+++ b/tools/proto-compiler/src/cmd/compile.rs
@@ -147,6 +147,16 @@ impl CompileCmd {
             .server_mod_attribute(".", r#"#[cfg(feature = "server")]"#)
             .out_dir(out_dir)
             .file_descriptor_set_path(out_dir.join("proto_descriptor.bin"))
+            // Use the v0.34 definition of `abci.Event` which does not enforce valid UTF-8 data
+            // for its `key` and `value` attributes, specifying them as `bytes` instead of `string`.
+            // This is required, because ibc-go emits event attributes which are not valid UTF-8,
+            // so we need to use this definition to be able to parse them.
+            // In Protobuf, `bytes` and `string` are wire-compatible, so doing this strictly
+            // increases the amount fo data we can parse.
+            .extern_path(
+                ".tendermint.abci.Event",
+                "::tendermint_proto::v0_34::abci::Event",
+            )
             .extern_path(".tendermint", "::tendermint_proto")
             .extern_path(".ics23", "::ics23")
             .type_attribute(".google.protobuf.Any", attrs_eq)


### PR DESCRIPTION
Closes: #181

Use the v0.34 definition of `abci.Event` which does not enforce valid UTF-8 data for its `key` and `value` attributes, specifying them as `bytes` instead of `string`. This is required, because ibc-go emits event attributes which are not valid UTF-8, so we need to use this definition to be able to parse them. In Protobuf, `bytes` and `string` are wire-compatible, so doing this strictly increases the amount fo data we can parse.

See this Hermes PR for background information: https://github.com/informalsystems/hermes/pull/3768