### PR TITLE
Proto compilation fixes

### DIFF
--- a/scripts/sync-protobuf.sh
+++ b/scripts/sync-protobuf.sh
@@ -22,11 +22,11 @@ set -eou pipefail
 # repositories over and over again every time
 # the script is called.
 
-CACHE_PATH="${XDG_CACHE_HOME:-$HOME/.cache}"
-COSMOS_SDK_GIT="${COSMOS_SDK_GIT:-$CACHE_PATH/cosmos/cosmos-sdk.git}"
+CACHE_PATH="${XDG_CACHE_HOME:-$HOME/.cache}"/ibc-proto-rs-build
+COSMOS_SDK_GIT="${COSMOS_SDK_GIT:-$CACHE_PATH/cosmos-sdk.git}"
 IBC_GO_GIT="${IBC_GO_GIT:-$CACHE_PATH/ibc-go.git}"
-COSMOS_ICS_GIT="${COSMOS_ICS_GIT:-$CACHE_PATH/cosmos/interchain-security.git}"
-NFT_TRANSFER_GIT="${NFT_TRANSFER_GIT:-$CACHE_PATH/bianjieai/nft-transfer.git}"
+COSMOS_ICS_GIT="${COSMOS_ICS_GIT:-$CACHE_PATH/interchain-security.git}"
+NFT_TRANSFER_GIT="${NFT_TRANSFER_GIT:-$CACHE_PATH/nft-transfer.git}"
 
 COSMOS_SDK_COMMIT="$(cat src/COSMOS_SDK_COMMIT)"
 IBC_GO_COMMIT="$(cat src/IBC_GO_COMMIT)"

--- a/tools/proto-compiler/src/cmd/compile.rs
+++ b/tools/proto-compiler/src/cmd/compile.rs
@@ -69,42 +69,42 @@ impl CompileCmd {
             out_dir.display()
         );
 
-        let root = env!("CARGO_MANIFEST_DIR");
+        let root = Path::new(env!("CARGO_MANIFEST_DIR"));
 
         // Paths
         let proto_paths = [
-            format!("{}/../../definitions/mock", root),
-            format!("{}/../../definitions/ibc/lightclients/localhost/v1", root),
-            format!("{}/../../definitions/stride/interchainquery/v1", root),
-            format!("{}/ibc", ibc_dir.display()),
-            format!("{}/cosmos/auth", sdk_dir.display()),
-            format!("{}/cosmos/gov", sdk_dir.display()),
-            format!("{}/cosmos/tx", sdk_dir.display()),
-            format!("{}/cosmos/base", sdk_dir.display()),
-            format!("{}/cosmos/crypto", sdk_dir.display()),
-            format!("{}/cosmos/bank", sdk_dir.display()),
-            format!("{}/cosmos/staking", sdk_dir.display()),
-            format!("{}/cosmos/upgrade", sdk_dir.display()),
-            format!("{}/interchain_security/ccv/v1", ics_dir.display()),
-            format!("{}/interchain_security/ccv/provider", ics_dir.display()),
-            format!("{}/interchain_security/ccv/consumer", ics_dir.display()),
-            format!("{}/ibc", nft_dir.display()),
+            root.join("../../definitions/mock"),
+            root.join("../../definitions/ibc/lightclients/localhost/v1"),
+            root.join("../../definitions/stride/interchainquery/v1"),
+            ibc_dir.join("ibc"),
+            sdk_dir.join("cosmos/auth"),
+            sdk_dir.join("cosmos/gov"),
+            sdk_dir.join("cosmos/tx"),
+            sdk_dir.join("cosmos/base"),
+            sdk_dir.join("cosmos/crypto"),
+            sdk_dir.join("cosmos/bank"),
+            sdk_dir.join("cosmos/staking"),
+            sdk_dir.join("cosmos/upgrade"),
+            ics_dir.join("interchain_security/ccv/v1"),
+            ics_dir.join("interchain_security/ccv/provider"),
+            ics_dir.join("interchain_security/ccv/consumer"),
+            nft_dir.join("ibc"),
         ];
 
         let proto_includes_paths = [
-            format!("{}", sdk_dir.display()),
-            format!("{}", ibc_dir.display()),
-            format!("{}", ics_dir.display()),
-            format!("{}", nft_dir.display()),
-            format!("{}/../../definitions/mock", root),
-            format!("{}/../../definitions/ibc/lightclients/localhost/v1", root),
-            format!("{}/../../definitions/stride/interchainquery/v1", root),
+            sdk_dir.to_path_buf(),
+            ibc_dir.to_path_buf(),
+            ics_dir.to_path_buf(),
+            nft_dir.to_path_buf(),
+            root.join("../../definitions/mock"),
+            root.join("../../definitions/ibc/lightclients/localhost/v1"),
+            root.join("../../definitions/stride/interchainquery/v1"),
         ];
 
         // List available proto files
         let mut protos: Vec<PathBuf> = vec![];
         for proto_path in &proto_paths {
-            println!("Looking for proto files in {:?}", proto_path);
+            println!("Looking for proto files in '{}'", proto_path.display());
             protos.append(
                 &mut WalkDir::new(proto_path)
                     .into_iter()
@@ -122,12 +122,9 @@ impl CompileCmd {
         println!("Found the following protos:");
         // Show which protos will be compiled
         for proto in &protos {
-            println!("\t-> {:?}", proto);
+            println!("\t-> {}", proto.display());
         }
         println!("[info ] Compiling..");
-
-        // List available paths for dependencies
-        let includes: Vec<PathBuf> = proto_includes_paths.iter().map(PathBuf::from).collect();
 
         let attrs_jsonschema = r#"#[cfg_attr(all(feature = "json-schema", feature = "serde"), derive(::schemars::JsonSchema))]"#;
         let attrs_jsonschema_str = r#"#[cfg_attr(all(feature = "json-schema", feature = "serde"), schemars(with = "String"))]"#;
@@ -170,7 +167,7 @@ impl CompileCmd {
             .type_attribute(".ibc.core.connection.v1.Counterparty", attrs_jsonschema)
             .type_attribute(".ibc.core.connection.v1.Version", attrs_jsonschema)
             .type_attribute(".ibc.lightclients.wasm.v1.ClientMessage", attrs_jsonschema)
-            .compile_with_config(config, &protos, &includes)?;
+            .compile_with_config(config, &protos, &proto_includes_paths)?;
 
         println!("[info ] Protos compiled successfully");
 


### PR DESCRIPTION
A couple minor fixes to the code generation infrastructure:

* Don't format `Path` into (potentially garbled) strings to compose new paths. There is a `Path`-native API for that. The resulting code is also less crufty.

* Use a single distinctive subdirectory under `~/.cache` to house all
checkouts for the build script, as per the XDG convention.