### PR TITLE
Export `tendermint_proto::Error`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@
 
 pub mod google;
 
+pub use tendermint_proto::Error;
 pub use tendermint_proto::Protobuf;
 
 extern crate alloc;


### PR DESCRIPTION
Exports the `tendermint_proto::Error` type so that it can be used in `ibc-rs` without having to also rely on the `tendermint-proto` dependency outright. 