### PR TITLE
feat: re-export google protos from `tendermint_proto`

### DIFF
--- a/.changelog/unreleased/features/242-re-export-google-protos-from-tendermint-proto.md
+++ b/.changelog/unreleased/features/242-re-export-google-protos-from-tendermint-proto.md
@@ -1,0 +1,2 @@
+- Re-export Google proto types from the `tendermint_proto` for added convenience
+  ([\#242](https://github.com/cosmos/ibc-proto-rs/pull/242))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,11 @@ pub const NFT_TRANSFER_COMMIT: &str = include_str!("NFT_TRANSFER_COMMIT");
 #[cfg(feature = "proto-descriptor")]
 pub const FILE_DESCRIPTOR_SET: &[u8] = include_bytes!("prost/proto_descriptor.bin");
 
+// Re-export the Google protos from the `tendermint_proto` crate
+pub mod google {
+    pub use tendermint_proto::google::*;
+}
+
 // Re-export Cosmos SDK protos from the `cosmos_sdk_proto` crate
 pub use cosmos_sdk_proto::cosmos;
 


### PR DESCRIPTION
## Description

Re-exporting Google protos from `tendermint_proto` because I couldn't properly upgrade `ibc-proto-rs` to v0.48.0 in `ibc-rs`. Starting with v0.48, `ibc-proto-rs` no longer includes WKT types, which forces `ibc-rs` to add a `tendermint-proto` dependency in several crates. We're trying to decouple `ibc-rs` from the `tendermint-rs` crates (except for the ICS-07 Tendermint light client), so this feels like a step back. Ideally, `ibc-rs` should stay only dependant on `ibc-proto-rs`.

In the future, if `tendermint-proto` is split into a separate repository and the IBC core proto types are decoupled from the `tendermint-proto` dependency as well, we achieve full separation and avoid any potential dependency conflicts in ibc-rs. Though it's not urgent now, stating it as a longer term goal.

