### PR TITLE
Update cosmos-sdk-proto to `v0.26.0`

### DIFF
--- a/.changelog/unreleased/breaking-changes/249-tendermint-proto-0-40-0.md
+++ b/.changelog/unreleased/breaking-changes/249-tendermint-proto-0-40-0.md
@@ -1,0 +1,2 @@
+- Update `cosmos-sdk-proto` to `v0.26.0`
+  ([\#249](https://github.com/cosmos/ibc-proto-rs/issues/249))

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ version          = "0.40.0"
 default-features = false
 
 [dependencies.cosmos-sdk-proto]
-version = "0.25.0"
+version = "0.26.0"
 default-features = false
 
 [dev-dependencies]


### PR DESCRIPTION
Closes #249 